### PR TITLE
initial information cards, missing trustee and pet api's

### DIFF
--- a/sc4p-frontend/src/components/InformationCard.tsx
+++ b/sc4p-frontend/src/components/InformationCard.tsx
@@ -245,9 +245,9 @@ const PurposeCard: React.FC<CardProps> = ({
 
 {purpose == "emergency_contact" && (
         <div className="flex items-center justify-between w-full">
-          {/* Facility Layout */}
+          {/* emergency Layout */}
           <div className="flex items-center gap-8">
-            {/* Facility Info */}
+            {/* emergency Info */}
             <div>
               <div className="flex gap-8 items-center">
                 <h4 className="text-xl font-semibold text-black mb-1">

--- a/sc4p-frontend/src/components/InformationCard.tsx
+++ b/sc4p-frontend/src/components/InformationCard.tsx
@@ -1,42 +1,109 @@
 import React from "react";
-import { Image, Card, Button } from "@nextui-org/react";
+import { Card, 
+  Button, 
+  Modal, 
+  Input,
+  ButtonGroup,
+  CardBody,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Radio,
+  RadioGroup,
+  useDisclosure,
+} from "@nextui-org/react";
+import { useState } from "react";
 import petTemplate from "../images/petTemplate.png";
 
 type CardProps = {
-  purpose: "pet" | "caregiver"; // Defines the purpose of the card
-  imageSrc: string; // URL for the image
+  purpose: "pet" | "caregiver" | "boarding_facilities" | "trust" | "emergency_contact"; // Defines the purpose of the card
   name: string; // Name (e.g., pet's name or caregiver's name)
   petType?: string; // Pet's type (if purpose is "pet")
   phone?: string; // Caregiver's phone number (if purpose is "caregiver")
-  email?: string; // Caregiver's email (if purpose is "caregiver")
+  email?: string | null; // Caregiver's email (if purpose is "caregiver")
   relation?: string; // Relationship (e.g., Primary for caregiver)
+  care_type?: string;// long or short term
+  accepted?: string; // whether or not they accept
+  address?: string; 
+  city?: string;
+  state?: string;
+  zip?: string;
+  home_phone?: string | null;
+  daily_charge?: number;
+  id?: number;
+  deleteItem?: (id: number) => void;
 };
 
 const PurposeCard: React.FC<CardProps> = ({
   purpose,
-  imageSrc,
   name,
   petType,
   phone,
   email,
   relation,
+  care_type,
+  accepted,
+  address,
+  city,
+  state,
+  zip,
+  home_phone,
+  daily_charge,
+  id,
+  deleteItem,
 }) => {
+
+  const [showPopup, setShowPopup] = useState(false);
+
+  const togglePopup = () => setShowPopup((prev) => !prev);
+
+  const handleSave = () => {
+    setShowPopup(false); // Close the popup after saving
+  };
+
+
+  const [editableData, setEditableData] = useState({
+    name,
+    petType,
+    phone,
+    email,
+    relation,
+    care_type,
+    accepted,
+    address,
+    city,
+    state,
+    zip,
+    home_phone,
+    daily_charge,
+  });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setEditableData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleDelete = () => {
+    if (id && deleteItem) {
+      deleteItem(id); // Call the delete function passed from parent with the id
+    }
+  };
+
+
   return (
+
     <Card
       className={`flex items-center justify-between p-4 bg-[#e6d1ff] bg-opacity-25 shadow-sm shadow-[#AF94D3] rounded-lg w-full mb-4`}
     >
-      {purpose === "pet" ? (
+      {purpose === "pet" && (
         <div className="flex items-center justify-between w-full">
           {/* Pet Layout */}
           <div className="flex items-center gap-8">
-            {/* Image */}
-            <Image
-              src={imageSrc}
-              alt={`${name} photo`}
-              width={64}
-              height={64}
-              className="rounded object-cover"
-            />
+            
             {/* Pet Info */}
             <div>
               <h4 className="text-xl font-semibold text-black mb-1">{name}</h4>
@@ -47,22 +114,17 @@ const PurposeCard: React.FC<CardProps> = ({
           <Button
             className="bg-white text-purple-600 border border-purple-500 hover:bg-purple-200"
             radius="md"
+            onClick={togglePopup}
           >
-            Update
+            {showPopup ? "See Less" : "See More"}
           </Button>
         </div>
-      ) : (
+      )}
+      
+      {purpose == "caregiver" && (
         <div className="flex items-center justify-between w-full">
           {/* Caregiver Layout */}
           <div className="flex items-center gap-8">
-            {/* Image */}
-            <Image
-              src={imageSrc}
-              alt={`${name} photo`}
-              width={64}
-              height={64}
-              className="rounded object-cover"
-            />
             {/* Caregiver Info */}
             <div>
               <div className="flex gap-8 items-center">
@@ -85,17 +147,427 @@ const PurposeCard: React.FC<CardProps> = ({
               </div>
             </div>
           </div>
+    {/* Button Container */}
+    <div className="flex gap-4">
+      {/* See More Button */}
+      <Button
+        className="bg-white text-purple-600 border border-purple-500 hover:bg-purple-200 mt-4"
+        radius="md"
+        onClick={togglePopup}
+      >
+        {showPopup ? "See Less" : "See More"}
+      </Button>
+      {/* Delete Button */}
+      <Button
+        className="bg-red-500 text-white mt-4"
+        onClick={handleDelete}
+        radius="md"
+      >
+        Delete
+      </Button>
+        </div>
+      </div>
+      )}
+
+      {purpose == "boarding_facilities" && (
+        <div className="flex items-center justify-between w-full">
+          {/* Facility Layout */}
+          <div className="flex items-center gap-8">
+            {/* Facility Info */}
+            <div>
+              <div className="flex gap-8 items-center">
+                <h4 className="text-xl font-semibold text-black mb-1">
+                  {name}
+                </h4>
+              </div>
+              <div className="flex gap-8">
+                <p className="text-sm text-black font-semibold">
+                  Phone <span className="text-gray-500 ml-1">{phone}</span>
+                </p>
+                <p className="text-sm text-black font-semibold">
+                  Email <span className="text-gray-500 ml-1">{email}</span>
+                </p>
+              </div>
+            </div>
+          </div>
+          {/* Button Container */}
+    <div className="flex gap-4">
+      {/* See More Button */}
+      <Button
+        className="bg-white text-purple-600 border border-purple-500 hover:bg-purple-200 mt-4"
+        radius="md"
+        onClick={togglePopup}
+      >
+        {showPopup ? "See Less" : "See More"}
+      </Button>
+      {/* Delete Button */}
+      <Button
+        className="bg-red-500 text-white mt-4"
+        onClick={handleDelete}
+        radius="md"
+      >
+        Delete
+      </Button>
+          </div>
+        </div>
+      )}
+
+      {purpose == "trust" && (
+        <div className="flex items-center justify-between w-full">
+          {/* Trust Layout */}
+          <div className="flex items-center gap-8">
+            {/* Trust Info */}
+            <div>
+              <div className="flex gap-8 items-center">
+                <h4 className="text-xl font-semibold text-black mb-1">
+                  {name}
+                </h4>
+              </div>
+              <div className="flex gap-8">
+                <p className="text-sm text-black font-semibold">
+                  Phone <span className="text-gray-500 ml-1">{phone}</span>
+                </p>
+                <p className="text-sm text-black font-semibold">
+                  Email <span className="text-gray-500 ml-1">{email}</span>
+                </p>
+              </div>
+            </div>
+          </div>
           {/* Button */}
           <Button
             className="bg-white text-purple-600 border border-purple-500 hover:bg-purple-200"
             radius="md"
           >
-            Update
+            See More
           </Button>
         </div>
       )}
-    </Card>
-  );
-};
+
+{purpose == "emergency_contact" && (
+        <div className="flex items-center justify-between w-full">
+          {/* Facility Layout */}
+          <div className="flex items-center gap-8">
+            {/* Facility Info */}
+            <div>
+              <div className="flex gap-8 items-center">
+                <h4 className="text-xl font-semibold text-black mb-1">
+                  {name}
+                </h4>
+              </div>
+              <div className="flex gap-8">
+                <p className="text-sm text-black font-semibold">
+                  Phone <span className="text-gray-500 ml-1">{phone}</span>
+                </p>
+                <p className="text-sm text-black font-semibold">
+                  Email <span className="text-gray-500 ml-1">{email}</span>
+                </p>
+              </div>
+            </div>
+          </div>
+          {/* Button Container */}
+    <div className="flex gap-4">
+      {/* See More Button */}
+      <Button
+        className="bg-white text-purple-600 border border-purple-500 hover:bg-purple-200 mt-4"
+        radius="md"
+        onClick={togglePopup}
+      >
+        {showPopup ? "See Less" : "See More"}
+      </Button>
+      {/* Delete Button */}
+      <Button
+        className="bg-red-500 text-white mt-4"
+        onClick={handleDelete}
+        radius="md"
+      >
+        Delete
+      </Button>
+          </div>
+        </div>
+      )}
+
+
+
+    {showPopup && (
+      <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+       <div className="bg-white p-6 rounded-lg shadow-lg max-w-lg w-full">
+          <div className="flex flex-col space-y-4">
+
+          {purpose === "caregiver" && (
+          <div>
+            <h3 className="text-lg font-semibold mb-4">{editableData.name}</h3>
+            <div className="text-sm text-gray-600">
+              {/* Flex row for fields */}
+              <div className="grid grid-cols-2 gap-4">
+                <div className="mb-4">
+                  <label className="block">Phone Number</label>
+                  <Input
+                    fullWidth
+                    name="phone"
+                    value={editableData.phone || ""}
+                    onChange={handleChange}
+                    placeholder="Phone"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Email</label>
+                  <Input
+                    fullWidth
+                    name="email"
+                    value={editableData.email || ""}
+                    onChange={handleChange}
+                    placeholder="Email"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Care Type</label>
+                  <Input
+                    fullWidth
+                    name="care_type"
+                    value={editableData.care_type || ""}
+                    onChange={handleChange}
+                    placeholder="Care Type"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Relation</label>
+                  <Input
+                    fullWidth
+                    name="relation"
+                    value={editableData.relation || ""}
+                    onChange={handleChange}
+                    placeholder="Relation"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Accepted</label>
+                  <Input
+                    fullWidth
+                    name="accepted"
+                    value={editableData.accepted || ""}
+                    onChange={handleChange}
+                    placeholder="Accepted"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Address</label>
+                  <Input
+                    fullWidth
+                    name="address"
+                    value={editableData.address || ""}
+                    onChange={handleChange}
+                    placeholder="Address"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">City</label>
+                  <Input
+                    fullWidth
+                    name="city"
+                    value={editableData.city || ""}
+                    onChange={handleChange}
+                    placeholder="City"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">State</label>
+                  <Input
+                    fullWidth
+                    name="state"
+                    value={editableData.state || ""}
+                    onChange={handleChange}
+                    placeholder="State"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Zip</label>
+                  <Input
+                    fullWidth
+                    name="zip"
+                    value={editableData.zip || ""}
+                    onChange={handleChange}
+                    placeholder="Zip"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {purpose === "boarding_facilities" && (
+          <div>
+            <h3 className="text-lg font-semibold mb-4">{editableData.name}</h3>
+            <div className="text-sm text-gray-600">
+              {/* Flex row for fields */}
+              <div className="grid grid-cols-2 gap-4">
+                <div className="mb-4">
+                  <label className="block">Phone Number</label>
+                  <Input
+                    fullWidth
+                    name="phone"
+                    value={editableData.phone || ""}
+                    onChange={handleChange}
+                    placeholder="Phone"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Home Number</label>
+                  <Input
+                    fullWidth
+                    name="Home phone"
+                    value={editableData.home_phone|| ""}
+                    onChange={handleChange}
+                    placeholder="Home Phone"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Daily Charge</label>
+                  <Input
+                    label="Average Daily Charge"
+                    placeholder="Enter average daily charge"
+                    type="number"
+                    isRequired
+                    labelPlacement="outside"
+                   />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Email</label>
+                  <Input
+                    fullWidth
+                    name="email"
+                    value={editableData.email || ""}
+                    onChange={handleChange}
+                    placeholder="Email"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Address</label>
+                  <Input
+                    fullWidth
+                    name="address"
+                    value={editableData.address || ""}
+                    onChange={handleChange}
+                    placeholder="Address"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">City</label>
+                  <Input
+                    fullWidth
+                    name="city"
+                    value={editableData.city || ""}
+                    onChange={handleChange}
+                    placeholder="City"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">State</label>
+                  <Input
+                    fullWidth
+                    name="state"
+                    value={editableData.state || ""}
+                    onChange={handleChange}
+                    placeholder="State"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Zip</label>
+                  <Input
+                    fullWidth
+                    name="zip"
+                    value={editableData.zip || ""}
+                    onChange={handleChange}
+                    placeholder="Zip"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {purpose === "emergency_contact" && (
+          <div>
+            <h3 className="text-lg font-semibold mb-4">{editableData.name}</h3>
+            <div className="text-sm text-gray-600">
+              {/* Flex row for fields */}
+              <div className="grid grid-cols-2 gap-4">
+                <div className="mb-4">
+                  <label className="block">Phone Number</label>
+                  <Input
+                    fullWidth
+                    name="phone"
+                    value={editableData.phone || ""}
+                    onChange={handleChange}
+                    placeholder="Phone"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Email</label>
+                  <Input
+                    fullWidth
+                    name="email"
+                    value={editableData.email || ""}
+                    onChange={handleChange}
+                    placeholder="Email"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Address</label>
+                  <Input
+                    fullWidth
+                    name="address"
+                    value={editableData.address || ""}
+                    onChange={handleChange}
+                    placeholder="Address"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">City</label>
+                  <Input
+                    fullWidth
+                    name="city"
+                    value={editableData.city || ""}
+                    onChange={handleChange}
+                    placeholder="City"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">State</label>
+                  <Input
+                    fullWidth
+                    name="state"
+                    value={editableData.state || ""}
+                    onChange={handleChange}
+                    placeholder="State"
+                  />
+                </div>
+                <div className="mb-4">
+                  <label className="block">Zip</label>
+                  <Input
+                    fullWidth
+                    name="zip"
+                    value={editableData.zip || ""}
+                    onChange={handleChange}
+                    placeholder="Zip"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <Button
+          className="bg-purple-600 text-white mt-4"
+          radius="md"
+          onClick={handleSave}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  </div>
+)}
+        </Card>
+  )};
 
 export default PurposeCard;

--- a/sc4p-frontend/src/pages/Caregivers.tsx
+++ b/sc4p-frontend/src/pages/Caregivers.tsx
@@ -20,6 +20,7 @@ import {
 import { useAuth } from "../AuthContext";
 import { CreateCaregiver, Caregiver } from "~/types/caregiver";
 import { BoardingFac, CreateBoardingFac } from "~/types/boardingFac";
+import InformationCard from "../components/InformationCard";
 import {
   getCaregivers,
   createCaregiver,
@@ -497,27 +498,21 @@ const Caregivers = () => {
                 key={caregiver.id}
                 className="p-4 border rounded-lg bg-white shadow-sm flex justify-between items-center"
               >
-                <div className="flex flex-col gap-1">
-                  <h3 className="text-lg font-semibold">{caregiver.name}</h3>
-                  <div className="text-sm text-gray-600">
-                    <p>Phone: {caregiver.phone}</p>
-                    <p>Email: {caregiver.email}</p>
-                    <p>Care Type: {caregiver.care_type}</p>
-                    <p>Role: {caregiver.primary ? "Primary" : "Secondary"}</p>
-                    <p>Accepted: {caregiver.accepted ? "Yes" : "No"}</p>
-                    <p className="text-xs text-gray-500">
-                      {caregiver.address}, {caregiver.city}, {caregiver.state}{" "}
-                      {caregiver.zip}
-                    </p>
-                  </div>
-                </div>
-                <Button
-                  color="danger"
-                  variant="light"
-                  onPress={() => handleDelete(caregiver.id)}
-                >
-                  Delete
-                </Button>
+                <InformationCard
+                purpose="caregiver"
+                name = {caregiver.name}
+                phone= {caregiver.phone}
+                email= {caregiver.email}
+                relation= {caregiver.primary ? "Primary" : "Secondary"}
+                care_type= {caregiver.care_type}
+                accepted= {caregiver.accepted ? "Yes" : "No"}
+                address= {caregiver.address}
+                city= {caregiver.city}
+                state={caregiver.state}
+                zip={caregiver.zip}
+                id={caregiver.id}
+                deleteItem={handleDelete}
+                />
               </div>
             ))}
             {caregivers.length === 0 && (
@@ -536,30 +531,20 @@ const Caregivers = () => {
                 key={facility.id}
                 className="p-4 border rounded-lg bg-white shadow-sm flex justify-between items-center"
               >
-                <div className="flex flex-col gap-1">
-                  <h3 className="text-lg font-semibold">
-                    {facility.contact_name}
-                  </h3>
-                  <div className="text-sm text-gray-600">
-                    <p>Daily Charge: ${facility.daily_charge}</p>
-                    <p>Cell Phone: {facility.cell_phone}</p>
-                    {facility.home_phone && (
-                      <p>Home Phone: {facility.home_phone}</p>
-                    )}
-                    {facility.email && <p>Email: {facility.email}</p>}
-                    <p className="text-xs text-gray-500">
-                      {facility.address}, {facility.city}, {facility.state}{" "}
-                      {facility.zip}
-                    </p>
-                  </div>
-                </div>
-                <Button
-                  color="danger"
-                  variant="light"
-                  onPress={() => handleDeleteFacility(facility.id)}
-                >
-                  Delete
-                </Button>
+                <InformationCard
+                purpose="boarding_facilities"
+                name= {facility.contact_name}
+                phone= {facility.cell_phone}
+                home_phone = {facility.home_phone}
+                daily_charge={facility.daily_charge}
+                email= {facility.email}
+                address= {facility.address}
+                city= {facility.city}
+                state={facility.state}
+                zip={facility.zip}
+                id = {facility.id}
+                deleteItem={handleDeleteFacility}
+                />
               </div>
             ))}
             {boardingFacilities.length === 0 && (

--- a/sc4p-frontend/src/pages/EmergencyContact.tsx
+++ b/sc4p-frontend/src/pages/EmergencyContact.tsx
@@ -25,6 +25,7 @@ import type {
   CreateEmergencyContact,
 } from "../types/emergencyContact";
 
+import InformationCard from "../components/InformationCard";
 const contactSchema = yup.object().shape({
   name: yup
     .string()
@@ -310,11 +311,18 @@ const EmergencyContactPage: React.FC = () => {
 
       <div className="w-full mt-6 grid gap-4">
         {emergencyContacts.map((contact) => (
-          <ContactCard
-            key={contact.id}
-            contact={contact}
-            onDelete={handleDelete}
-          />
+          <InformationCard
+                purpose="emergency_contact"
+                name = {contact.name}
+                phone= {contact.phone}
+                email= {contact.email}
+                address= {contact.address}
+                city= {contact.city}
+                state={contact.state}
+                zip={contact.zip}
+                id={contact.id}
+                deleteItem={handleDelete}
+            />
         ))}
         {emergencyContacts.length === 0 && (
           <div className="text-center text-gray-500 py-8">

--- a/sc4p-frontend/src/pages/Pets.tsx
+++ b/sc4p-frontend/src/pages/Pets.tsx
@@ -474,21 +474,18 @@ const Pets: React.FC = () => {
         {/* First Pet */}
         <InformationCard
           purpose="pet"
-          imageSrc="https://via.placeholder.com/64"
           name="Oreo"
           petType="Dog"
         />
         {/* Second Pet */}
         <InformationCard
           purpose="pet"
-          imageSrc="https://via.placeholder.com/64"
           name="Whiskers"
           petType="Cat"
         />
         {/* Third Pet */}
         <InformationCard
           purpose="pet"
-          imageSrc="https://via.placeholder.com/64"
           name="Chirpy"
           petType="Bird"
         />


### PR DESCRIPTION
Was able to make the information card into a prop that changes based on purpose. Trustees and pet's are missing apis to populate an array and then map with the information prop but working for caregivers, facilities, and emergency contacts. Also made "see more" into a pop up that allows for basic editing of some of the fields for now

<img width="1512" alt="Screenshot 2025-01-18 at 10 54 35 PM" src="https://github.com/user-attachments/assets/53d045b8-1f37-4427-821d-ae35bd5a57a0" />
<img width="1512" alt="Screenshot 2025-01-18 at 10 54 43 PM" src="https://github.com/user-attachments/assets/fb347ec4-c2d2-458e-870b-02da15e2d515" />
<img width="1512" alt="Screenshot 2025-01-18 at 10 59 40 PM" src="https://github.com/user-attachments/assets/02204c18-1319-4d87-9039-56d5672b0de3" />
<img width="1512" alt="Screenshot 2025-01-18 at 11 00 03 PM" src="https://github.com/user-attachments/assets/38696b65-6591-43f3-bfbb-f33663ec1c52" />

